### PR TITLE
Update the shadowCredentialsAttack

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -242,6 +242,10 @@ class LDAPAttack(ProtocolAttack):
         if self.config.ShadowCredentialsTarget in delegatePerformed:
             LOG.info('Shadow credentials attack already performed for %s, skipping' % self.config.ShadowCredentialsTarget)
             return
+        # If the target is not specify, we try to modify the user himself
+        if not self.config.ShadowCredentialsTarget:
+            self.config.ShadowCredentialsTarget = self.username
+
         LOG.info("Searching for the target account")
 
         # Get the domain we are in


### PR DESCRIPTION
If no target is configured, the target will be the relayed user himself.
If by luck, this user has the rights to update its own `msDs-KeyCredentialLink`, we will be able to take over the user